### PR TITLE
Fix path to leaflet.js

### DIFF
--- a/templates/frame_v2.haml
+++ b/templates/frame_v2.haml
@@ -472,7 +472,7 @@
   {% endif %}
   <script src="{{ STATIC_URL }}js/uikit.js"></script>
   <script src="{{ STATIC_URL }}js/uikit-icons.js"></script>
-  <script src="{{ STATIC_URL }}/js/leaflet.js"></script>
+  <script src="{{ STATIC_URL }}js/leaflet.js"></script>
   <script src="https://code.highcharts.com/highcharts.js"></script>
   <script type="text/javascript" src="{{ STATIC_URL }}js/gradientfactory.js"></script>
   <script type="text/javascript" src="https://www.gstatic.com/charts/loader.js"></script>


### PR DESCRIPTION
corrected or leaflet.js path from https://ureport.ilhasoft.dev/sitestatic//js/leaflet.js
to https://ureport.ilhasoft.dev/sitestatic/js/leaflet.js