### PR TITLE
Update whitenoise to 5.0.1

### DIFF
--- a/weni_requirements.txt
+++ b/weni_requirements.txt
@@ -2,5 +2,5 @@ python-decouple==3.1
 raven==6.9.0
 typed-ast==1.4.1
 toml==0.10.1
-whitenoise==4.1.2
+whitenoise==5.0.1
 elastic-apm==6.1.1


### PR DESCRIPTION
In the [last PR](https://github.com/Ilhasoft/ureport/pull/149) merged the version of many packages was updated.
This caused problems as our extra packages ended up getting out of date. Therefore, this PR updates `whitenoise`  from `whitenoise==4.1.2` to `whitenoise==5.0.1`