### PR TITLE
Add environment variable needed by django ^= 4.0

### DIFF
--- a/ureport/settings.py.prod
+++ b/ureport/settings.py.prod
@@ -218,3 +218,8 @@ UREPORT_RUN_FETCHED_DATA_CACHE_TIME = config('UREPORT_RUN_FETCHED_DATA_CACHE_TIM
 
 TIME_ZONE = config('TIME_ZONE', default='America/Sao_Paulo')
 USER_TIME_ZONE = config('USER_TIME_ZONE', default='America/Sao_Paulo')
+
+
+CSRF_TRUSTED_ORIGINS = config(
+    "CSRF_TRUSTED_ORIGINS", default="https://*.ureport.in", cast=lambda v: [s.strip() for s in v.split(",")]
+)


### PR DESCRIPTION
Add environment variable needed by django ^= 4.0. [Reference](https://docs.djangoproject.com/en/4.0/ref/settings/#csrf-trusted-origins).