### PR TITLE
Adiciona permissão de execução ao docker-entrypoint.sh

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -113,6 +113,8 @@ RUN apt-get update \
 COPY --chown=app_user:app_group . . 
 RUN ln -s "${PROJECT_PATH}"/ureport/settings.py.prod "${PROJECT_PATH}"/ureport/settings.py
 
+RUN chmod +x "${PROJECT_PATH}"/docker-entrypoint.sh
+
 ENTRYPOINT ["/ureport/docker-entrypoint.sh"]
 
 CMD ["start"]


### PR DESCRIPTION
- Corrige o erro de inicialização "permission denied" no OCI runtime ao iniciar o container.
- O erro ocorria porque o arquivo /ureport/docker-entrypoint.sh não possuía a permissão de execução (+x) no filesystem da imagem final, impedindo o OCI runtime de iniciá-lo.
- A solução é adicionar 'RUN chmod +x' ao Dockerfile após a cópia do script.